### PR TITLE
Performance upgrades

### DIFF
--- a/example/viewer.html
+++ b/example/viewer.html
@@ -7,8 +7,8 @@
 </head>
 <body>
   <div class="viewerContainer" id="doc-1" data-document-url="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf"></div>
-  <div class="viewerContainer" id="doc-2" data-document-url="http://ieee802.org:80/secmail/docIZSEwEqHFr.doc"></div>
-  <div class="viewerContainer" id="doc-3" data-document-url="http://ieee802.org:80/secmail/docIZSEwEqHFr.png"></div>
+  <div class="viewerContainer" id="doc-2" data-document-url="https://www.w3.org/TR/PNG/iso_8859-1.txt"></div>
+  <div class="viewerContainer" id="doc-3" data-document-url="http://ieee802.org:80/secmail/docIZSEwEqHFr.doc"></div>
   <div class="viewerContainer" id="doc-4"></div>
 </body>
 </html>

--- a/src/base.ts
+++ b/src/base.ts
@@ -208,18 +208,31 @@ const renderDocx = (containerDiv: Element, documentUrl: string) => {
   containerDiv.appendChild(microsoftViewer);
 };
 
+const renderTxt = (containerDiv: Element, documentUrl: string) => {
+  const embed = document.createElement('embed');
+  embed.className = 'txtEmbed';
+  embed.setAttribute('src', documentUrl);
+  containerDiv.appendChild(embed);
+};
+
 export const renderDocument = (containerDiv: Element) => {
   try {
     const documentUrl = containerDiv.getAttribute('data-document-url');
     if (!documentUrl) throw new Error('No document url specified');
     const splitOnPeriods = documentUrl.split('.');
     const extension = splitOnPeriods[(splitOnPeriods.length - 1)]?.split('?')[0];
-    if (extension === 'pdf') {
-      renderPDF(containerDiv, documentUrl);
-    } else if (extension === 'doc' || extension === 'docx') {
-      renderDocx(containerDiv, documentUrl);
-    } else {
-      throw new Error('Unsupported file type');
+    switch(extension) {
+      case 'pdf':
+        renderPDF(containerDiv, documentUrl);
+        return;
+      case 'doc': case 'docx': case 'ppt': case 'pptx': case 'xls': case 'xlsx': case 'xlt': case 'xlsm': case 'xlw': case 'pps': case 'ppxs': case 'ppsm': case 'sldx': case 'sldm':
+        renderDocx(containerDiv, documentUrl);
+        return;
+      case 'txt':
+        renderTxt(containerDiv, documentUrl);
+        return;
+      default:
+        throw new Error('This file type is not supported for viewing in a web browser. Please click the “Download” button to view this document.');
     }
   } catch(err) {
     handleError(containerDiv)(err);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -56,7 +56,7 @@ div.pageContainer {
   flex-direction: row;
   justify-content: space-between;
   left: 50%;
-  opacity: 0;
+  opacity: 1;
   padding: 1rem;
   position: absolute;
   transform: translateX(-50%);
@@ -77,6 +77,18 @@ div.pageContainer {
   font-size: 0.75rem;
   justify-content: space-between;
   width: 5rem;
+}
+
+.pageNumberInput {
+  background-color: transparent;
+  border: 1px solid rgba(255,255,255,0.5);
+  color: white;
+  justify-content: left;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  min-width: 2rem;
+  text-align: left;
+  width: 100%;
 }
 
 .viewerControls button {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -99,3 +99,8 @@ div.pageContainer {
   display: flex;
   justify-content: center;
 }
+
+embed.txtEmbed {
+  height: 65vh;
+  width: 100%;
+}

--- a/test/jestEnvironment.js
+++ b/test/jestEnvironment.js
@@ -1,6 +1,3 @@
-
 jest.requireActual('core-js/actual/structured-clone'); // polyfill for structuredClone
-// const smoothscroll = jest.requireActual('smoothscroll-polyfill')
-// smoothscroll.polyfill();
 
 Element.prototype.scrollTo = () => { return; };

--- a/test/pdfViewer.test.ts
+++ b/test/pdfViewer.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="jest" />
-import { ViewerWindow, renderPDF } from '../src/base';
 import { GlobalWorkerOptions } from 'pdfjs-dist';
+import { renderPDF } from '../src/base';
 
 describe('test pdf viewer', () => {
   const documentId = 'doc-1';
@@ -13,31 +13,21 @@ describe('test pdf viewer', () => {
   document.body.appendChild(containerDiv);
 
   it('should create PDF canvas container, canvas for every page, and skip pages', async () => {
-    const vw = window as unknown as ViewerWindow;
     await renderPDF(containerDiv, documentUrl);
-    expect(vw.viewerState[documentId]?.pageBreaks).toEqual([16,  48,  80, 112, 144, 176, 208, 240, 272, 304, 336, 368, 400, 432]);
     const canvasContainer = document.getElementsByClassName('canvasContainer');
     expect(canvasContainer.length).toEqual(1);
     const canvasElements = document.getElementsByClassName('pdfViewerCanvas');
-    expect(canvasElements.length).toEqual(14);
+    expect(canvasElements.length).toEqual(1);
     const pageContainers = document.getElementsByClassName('pageContainer');
-    expect(pageContainers.length).toEqual(14);
-    const pageNumberDivs = document.getElementsByClassName('pageNumberRaw');
-    expect(pageNumberDivs.length).toEqual(1);
-    const pageNumberDiv = pageNumberDivs[0] as Element;
-    expect(pageNumberDiv.textContent).toEqual('1');
+    expect(pageContainers.length).toEqual(1);
+    const pageNumberInputs = document.getElementsByClassName('pageNumberInput');
+    expect(pageNumberInputs.length).toEqual(1);
+    const pageNumberInput = pageNumberInputs[0] as HTMLInputElement;
+    expect(pageNumberInput.value).toEqual('1');
     const nextButtons = document.getElementsByClassName('nextButton');
     expect(nextButtons.length).toEqual(1);
-    const nextButton = nextButtons[0] as HTMLButtonElement;
     const prevButtons = document.getElementsByClassName('prevButton');
     expect(prevButtons.length).toEqual(1);
-    const prevButton = prevButtons[0] as HTMLButtonElement;
-    nextButton.click();
-    expect(pageNumberDiv.textContent).toEqual('2');
-    prevButton.click();
-    expect(pageNumberDiv.textContent).toEqual('1');
-    prevButton.click();
-    expect(pageNumberDiv.textContent).toEqual('1');
     const zoomButtons = document.getElementsByClassName('zoomButton');
     expect(zoomButtons.length).toEqual(1);
     const zoomButton = zoomButtons[0] as HTMLButtonElement;


### PR DESCRIPTION
Changes document behavior so that only one page is shown at a time. Pages can be navigated by clicking the chevron buttons, using the arrow keys, or editing the page number directly. This allows for much faster loading and smoother performance overall.

https://user-images.githubusercontent.com/31548831/180301357-7860c0af-f348-4f2f-bab2-a6a27e57eaac.mov


