### PR TITLE
Fixed doc viewer rendering twice in react18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-viewer-ts",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "PDF and MS Doc viewer written in TypeScript for React and vanilla JavaScript",
   "main": "dist/lib/index.js",
   "module": "dist/es2015/index.js",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -8,7 +8,14 @@ type ViewerProps = {
 
 export const Viewer: React.FC<ViewerProps> = (props: ViewerProps) => {
   const viewerContainer = useRef<HTMLDivElement>(null);
-  useEffect(() => { viewerContainer.current && renderDocument(viewerContainer.current); }, []);
+  useEffect(() => {
+    viewerContainer.current && renderDocument(viewerContainer.current);
+
+    return () => {
+      viewerContainer.current && viewerContainer.current.firstElementChild && viewerContainer.current.removeChild(viewerContainer.current.firstElementChild);
+    };
+  }, []);
+
   return <div
     ref={viewerContainer}
     className="viewer-container"


### PR DESCRIPTION
Removed the child node we are appending to the viewerContainer in the useEffect clean up function

![Screen Shot 2022-11-18 at 9 54 22 AM](https://user-images.githubusercontent.com/63620359/202770552-33d2c9f4-e375-46d7-8fce-bdda29d41138.png)
