### PR TITLE
Convert extension to lowercase before switching on it

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -259,7 +259,7 @@ export const renderDocument = (workerSrc: string) => (containerDiv: Element) => 
     containerDiv.classList.add('document-viewer-ts');
     if (!documentUrl) throw new Error('No document url specified');
     const splitOnPeriods = documentUrl.split('.');
-    const extension = splitOnPeriods[(splitOnPeriods.length - 1)]?.split('?')[0];
+    const extension = splitOnPeriods[(splitOnPeriods.length - 1)]?.split('?')[0]?.toLowerCase();
     switch(extension) {
       case 'pdf':
         try {


### PR DESCRIPTION
Currently documents with extensions that aren't all lowercase show an error

![image](https://user-images.githubusercontent.com/4718399/228234355-1cd182bb-251f-47b8-8a80-5204ac06196a.png)
